### PR TITLE
Fix #98

### DIFF
--- a/model/streams/O-OM-B.yml
+++ b/model/streams/O-OM-B.yml
@@ -9,7 +9,7 @@ practice: 8f07145b5ea74388b2217895d5e7b5c2
 id: a0d2ec4c6daa43369c07644b8745a7bd
 
 #Official stream name
-name: System Decomissioning / Legacy Management
+name: System Decommissioning / Legacy Management
 
 #Stream letter, A or B
 letter: B


### PR DESCRIPTION
The name(System Decommissioning / Legacy Management) had a typo Decomissioning instead of Decommissioning