### PR TITLE
feat(ci): build model markdown on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,15 @@
 name: Release
-
 on:
   pull_request:
     branches:
       - main
     types:
       - closed
-
 jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
+    if: github.event.pull_request.merged == true     # only merged pull requests must trigger this job
     steps:
       - name: Extract version from branch name (for release branches)
         if: startsWith(github.event.pull_request.head.ref, 'release/')
@@ -25,7 +23,7 @@ jobs:
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix/}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: tar -cvzf samm.tar.gz images model texts
       - name: Generate Excel spreadsheet from the model
         uses: owaspsamm/toolbox-spreadsheet@main
@@ -47,7 +45,7 @@ jobs:
         with:
           head: main
           base: develop
-          title: Merge master into dev branch
+          title: Merge main into develop branch
           body: |
-            This PR merges the master branch back into dev.
-            This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates are also present on the dev branch.
+            This PR merges the main branch back into develop.
+            This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates are also present on the develop branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#release/}
-          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION="${BRANCH_NAME#release/}"
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Extract version from branch name (for hotfix branches)
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix/}
-          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION="${BRANCH_NAME#hotfix/}"
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3
       - run: tar -cvzf samm.tar.gz images model texts
       - name: Generate Excel spreadsheet from the model

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,16 @@ jobs:
     steps:
       - name: Extract version from branch name (for release branches)
         if: startsWith(github.event.pull_request.head.ref, 'release/')
+        env:
+          BRANCH_NAME: "${{ github.event.pull_request.head.ref }}"
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION="${BRANCH_NAME#release/}"
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Extract version from branch name (for hotfix branches)
         if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          BRANCH_NAME: "${{ github.event.pull_request.head.ref }}"
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION="${BRANCH_NAME#hotfix/}"
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3

--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -25,12 +25,13 @@ jobs:
     needs: lintModelv20
     steps:
       - name: 'Checkout using release is workflow dispatched'
-        uses: actions/checkout@v3
         if: github.event.workflow_dispatch
-        ref: ${{ inputs.release }}
-      - name: 'Checkout from ref when push'
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release }}
+      - name: 'Checkout from ref when push'
         if: github.event.push
+        uses: actions/checkout@v3
       - name: 'Create output dir and copy files to override spaces in directories'
         run: |
           mkdir output
@@ -57,7 +58,7 @@ jobs:
           SQUASH_HISTORY: true
   # after changing something, we need to trigger the website build
   trigger-website-build:
-    if: github.event.push.tags && github.ref_type == "tag"
+    if: github.event.push.tags && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs: generate-markdown
     steps:

--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -1,35 +1,43 @@
 name: Generate Web Markdown
-
 on:
   push:
     paths:
       - '.github/workflows/*.yml'
       - 'model/**/*.yml'
-
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Generate Web Markdown for this SAMM release'
+        required: true
+        type: string
 jobs:
   lintModelv20:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: yaml-lint
-      run: |
-        yamllint -c .yamllint -f github model
-
+      - uses: actions/checkout@v3
+      - name: yaml-lint
+        run: |
+          yamllint -c .yamllint -f github model
   generate-markdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: lintModelv20
     steps:
-      - uses: actions/checkout@v2
-
+      - name: 'Checkout using release is workflow dispatched'
+        uses: actions/checkout@v3
+        if: github.event.workflow_dispatch
+        ref: ${{ inputs.release }}
+      - name: 'Checkout from ref when push'
+        uses: actions/checkout@v3
+        if: github.event.push
       - name: 'Create output dir and copy files to override spaces in directories'
         run: |
           mkdir output
-
       - name: 'Generate model for website'
         uses: docker://fzipi/owasp-samm-preprocess-yaml:version-0.8.1
         with:
           args: '-d model -o output'
-
       - name: 'Move generated files to common directory structure'
         run: |
           mkdir -p build/business-function/practice/stream
@@ -37,10 +45,8 @@ jobs:
           cp "$BASE"/{Design.md,Governance.md,Implementation.md,Operations.md,Verification.md} build/business-function
           cp "$BASE"/*-??-?.md build/business-function/practice/stream
           cp "$BASE"/*-??.md build/business-function/practice
-
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
-
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop
         env:
@@ -50,7 +56,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SQUASH_HISTORY: true
   # after changing something, we need to trigger the website build
-  #trigger-website-build:
-  #  runs-on: ubuntu-18.04
-  #  needs: generate-markdown
-
+  trigger-website-build:
+    if: github.event.push.tags && github.ref_type == "tag"
+    runs-on: ubuntu-latest
+    needs: generate-markdown
+    steps:
+      - name: Trigger Website Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: owaspsamm/website
+          event-type: samm-core-released
+          client-payload: '{"release": "${{ github.ref_name }}"}'


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This PR should generate the markdown files when a new SAMM version is released. There is also a new workflow dispatch that can be used to manually generate releases for older tags.