### PR TITLE
fix: use release name per workflow

### DIFF
--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -32,6 +32,16 @@ jobs:
       - name: 'Checkout from ref when push'
         if: github.event_name == 'push'
         uses: actions/checkout@v3
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - name: 'Set release env var from workflow dispatched'
+        if: github.event_name == 'push'
+        run: |
+          echo "release_name=${GITHUB_REF_SLUG}" >> $GITHUB_ENV
+      - name: 'Checkout using release is workflow dispatched'
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "release_name=${{ inputs.release }}" >> $GITHUB_ENV
       - name: 'Create output dir and copy files to override spaces in directories'
         run: |
           mkdir output
@@ -46,13 +56,11 @@ jobs:
           cp "$BASE"/{Design.md,Governance.md,Implementation.md,Operations.md,Verification.md} build/business-function
           cp "$BASE"/*-??-?.md build/business-function/practice/stream
           cp "$BASE"/*-??.md build/business-function/practice
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop
         env:
           REPO: self
-          BRANCH: markdown/${GITHUB_REF_SLUG}
+          BRANCH: markdown/${{ env.release_name }}
           FOLDER: build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SQUASH_HISTORY: true


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

We need to have a unique name but should be set per workflow.