### PR TITLE
Consistent naming for yaml-deserialization

### DIFF
--- a/model/practice_levels/D-SA-1.yml
+++ b/model/practice_levels/D-SA-1.yml
@@ -6,7 +6,7 @@
 practice: 4753e55e943c4d418303bf90d599c6b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-SA-2.yml
+++ b/model/practice_levels/D-SA-2.yml
@@ -6,7 +6,7 @@
 practice: 4753e55e943c4d418303bf90d599c6b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-SA-3.yml
+++ b/model/practice_levels/D-SA-3.yml
@@ -6,7 +6,7 @@
 practice: 4753e55e943c4d418303bf90d599c6b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-SR-1.yml
+++ b/model/practice_levels/D-SR-1.yml
@@ -6,7 +6,7 @@
 practice: 5702908efca4499e87a0239f32920d9b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-SR-2.yml
+++ b/model/practice_levels/D-SR-2.yml
@@ -6,7 +6,7 @@
 practice: 5702908efca4499e87a0239f32920d9b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-SR-3.yml
+++ b/model/practice_levels/D-SR-3.yml
@@ -6,7 +6,7 @@
 practice: 5702908efca4499e87a0239f32920d9b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-TA-1.yml
+++ b/model/practice_levels/D-TA-1.yml
@@ -6,7 +6,7 @@
 practice: f9269aebfe2c4d5b9293ba42a40a93ac
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-TA-2.yml
+++ b/model/practice_levels/D-TA-2.yml
@@ -6,7 +6,7 @@
 practice: f9269aebfe2c4d5b9293ba42a40a93ac
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/D-TA-3.yml
+++ b/model/practice_levels/D-TA-3.yml
@@ -6,7 +6,7 @@
 practice: f9269aebfe2c4d5b9293ba42a40a93ac
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-EG-1.yml
+++ b/model/practice_levels/G-EG-1.yml
@@ -6,7 +6,7 @@
 practice: 483a0a1b78264cafbc470ce72d557332
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-EG-2.yml
+++ b/model/practice_levels/G-EG-2.yml
@@ -6,7 +6,7 @@
 practice: 483a0a1b78264cafbc470ce72d557332
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-EG-3.yml
+++ b/model/practice_levels/G-EG-3.yml
@@ -6,7 +6,7 @@
 practice: 483a0a1b78264cafbc470ce72d557332
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-PC-1.yml
+++ b/model/practice_levels/G-PC-1.yml
@@ -6,7 +6,7 @@
 practice: be9e7ddb98b84abe8b9e185b979ccf60
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-PC-2.yml
+++ b/model/practice_levels/G-PC-2.yml
@@ -6,7 +6,7 @@
 practice: be9e7ddb98b84abe8b9e185b979ccf60
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-PC-3.yml
+++ b/model/practice_levels/G-PC-3.yml
@@ -6,7 +6,7 @@
 practice: be9e7ddb98b84abe8b9e185b979ccf60
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-SM-1.yml
+++ b/model/practice_levels/G-SM-1.yml
@@ -6,7 +6,7 @@
 practice: 32b3bdd85d3a4d53827960004f9d1c7e
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-SM-2.yml
+++ b/model/practice_levels/G-SM-2.yml
@@ -6,7 +6,7 @@
 practice: 32b3bdd85d3a4d53827960004f9d1c7e
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/G-SM-3.yml
+++ b/model/practice_levels/G-SM-3.yml
@@ -6,7 +6,7 @@
 practice: 32b3bdd85d3a4d53827960004f9d1c7e
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-DM-1.yml
+++ b/model/practice_levels/I-DM-1.yml
@@ -6,7 +6,7 @@
 practice: e17d573510904f65a1fe6040b56ad0b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-DM-2.yml
+++ b/model/practice_levels/I-DM-2.yml
@@ -6,7 +6,7 @@
 practice: e17d573510904f65a1fe6040b56ad0b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-DM-3.yml
+++ b/model/practice_levels/I-DM-3.yml
@@ -6,7 +6,7 @@
 practice: e17d573510904f65a1fe6040b56ad0b1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SB-1.yml
+++ b/model/practice_levels/I-SB-1.yml
@@ -6,7 +6,7 @@
 practice: b2af112859d34cada6ce4cf44d393b94
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SB-2.yml
+++ b/model/practice_levels/I-SB-2.yml
@@ -6,7 +6,7 @@
 practice: b2af112859d34cada6ce4cf44d393b94
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SB-3.yml
+++ b/model/practice_levels/I-SB-3.yml
@@ -6,7 +6,7 @@
 practice: b2af112859d34cada6ce4cf44d393b94
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SD-1.yml
+++ b/model/practice_levels/I-SD-1.yml
@@ -6,7 +6,7 @@
 practice: 40d7879025144dbbbf34ba8ea82f060d
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SD-2.yml
+++ b/model/practice_levels/I-SD-2.yml
@@ -6,7 +6,7 @@
 practice: 40d7879025144dbbbf34ba8ea82f060d
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/I-SD-3.yml
+++ b/model/practice_levels/I-SD-3.yml
@@ -6,7 +6,7 @@
 practice: 40d7879025144dbbbf34ba8ea82f060d
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-EM-1.yml
+++ b/model/practice_levels/O-EM-1.yml
@@ -6,7 +6,7 @@
 practice: 53a9cd5c2d3643f3b71e4e9d92b811e2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-EM-2.yml
+++ b/model/practice_levels/O-EM-2.yml
@@ -6,7 +6,7 @@
 practice: 53a9cd5c2d3643f3b71e4e9d92b811e2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-EM-3.yml
+++ b/model/practice_levels/O-EM-3.yml
@@ -6,7 +6,7 @@
 practice: 53a9cd5c2d3643f3b71e4e9d92b811e2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-IM-1.yml
+++ b/model/practice_levels/O-IM-1.yml
@@ -6,7 +6,7 @@
 practice: c13aa12c13d04362a3ca3385a8c580ee
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-IM-2.yml
+++ b/model/practice_levels/O-IM-2.yml
@@ -6,7 +6,7 @@
 practice: c13aa12c13d04362a3ca3385a8c580ee
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-IM-3.yml
+++ b/model/practice_levels/O-IM-3.yml
@@ -6,7 +6,7 @@
 practice: c13aa12c13d04362a3ca3385a8c580ee
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-OM-1.yml
+++ b/model/practice_levels/O-OM-1.yml
@@ -6,7 +6,7 @@
 practice: 8f07145b5ea74388b2217895d5e7b5c2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-OM-2.yml
+++ b/model/practice_levels/O-OM-2.yml
@@ -6,7 +6,7 @@
 practice: 8f07145b5ea74388b2217895d5e7b5c2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/O-OM-3.yml
+++ b/model/practice_levels/O-OM-3.yml
@@ -6,7 +6,7 @@
 practice: 8f07145b5ea74388b2217895d5e7b5c2
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-AA-1.yml
+++ b/model/practice_levels/V-AA-1.yml
@@ -6,7 +6,7 @@
 practice: 53f2da68c37a4ced8d5e767298fba589
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-AA-2.yml
+++ b/model/practice_levels/V-AA-2.yml
@@ -6,7 +6,7 @@
 practice: 53f2da68c37a4ced8d5e767298fba589
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-AA-3.yml
+++ b/model/practice_levels/V-AA-3.yml
@@ -6,7 +6,7 @@
 practice: 53f2da68c37a4ced8d5e767298fba589
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-RT-1.yml
+++ b/model/practice_levels/V-RT-1.yml
@@ -6,7 +6,7 @@
 practice: 66fb99798fe946e4979a2de98e9d6f8b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-RT-2.yml
+++ b/model/practice_levels/V-RT-2.yml
@@ -6,7 +6,7 @@
 practice: 66fb99798fe946e4979a2de98e9d6f8b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-RT-3.yml
+++ b/model/practice_levels/V-RT-3.yml
@@ -6,7 +6,7 @@
 practice: 66fb99798fe946e4979a2de98e9d6f8b
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-ST-1.yml
+++ b/model/practice_levels/V-ST-1.yml
@@ -6,7 +6,7 @@
 practice: bb5488860c124b6e8076b023485023e1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 0a1dc80f84964f2fa776c5d8e932353a
+maturityLevel: 0a1dc80f84964f2fa776c5d8e932353a
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-ST-2.yml
+++ b/model/practice_levels/V-ST-2.yml
@@ -6,7 +6,7 @@
 practice: bb5488860c124b6e8076b023485023e1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 47dd82af343e4695a0385418af4398d1
+maturityLevel: 47dd82af343e4695a0385418af4398d1
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/practice_levels/V-ST-3.yml
+++ b/model/practice_levels/V-ST-3.yml
@@ -6,7 +6,7 @@
 practice: bb5488860c124b6e8076b023485023e1
 
 #Link to the maturity level, using its unique identifier
-maturitylevel: 7bbfe31d447e48759ef0f2af25c31b43
+maturityLevel: 7bbfe31d447e48759ef0f2af25c31b43
 
 #Unique identifier (GUID) used to refer to this practice level.
 #Please generate another identifier for your specific practice level.

--- a/model/questions/D-SA-1-A.yml
+++ b/model/questions/D-SA-1-A.yml
@@ -6,7 +6,7 @@
 activity: 27bb61f3c6344359b021caeaef5ab07e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SA-1-B.yml
+++ b/model/questions/D-SA-1-B.yml
@@ -6,7 +6,7 @@
 activity: 27cdd2a336a44e56a42632c7a78fcf4f
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SA-2-A.yml
+++ b/model/questions/D-SA-2-A.yml
@@ -6,7 +6,7 @@
 activity: 9b6a86278ba14a9098d3d60a9a78d6c5
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SA-2-B.yml
+++ b/model/questions/D-SA-2-B.yml
@@ -6,7 +6,7 @@
 activity: 5e1dd310e28449058046c7af0fe46fce
 
 #Link to the answer set that contains the potential answers for this question
-answerset: b6fd4b86ecf04955befe9322ff338ca8
+answerSet: b6fd4b86ecf04955befe9322ff338ca8
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SA-3-A.yml
+++ b/model/questions/D-SA-3-A.yml
@@ -6,7 +6,7 @@
 activity: aa962032982a4d53bd34cd8771558df1
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SA-3-B.yml
+++ b/model/questions/D-SA-3-B.yml
@@ -6,7 +6,7 @@
 activity: 3afce608ad7c42deb37a04d6b86e5c33
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-1-A.yml
+++ b/model/questions/D-SR-1-A.yml
@@ -6,7 +6,7 @@
 activity: 91086153b98b46928e36dd031b27bdc2
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-1-B.yml
+++ b/model/questions/D-SR-1-B.yml
@@ -6,7 +6,7 @@
 activity: 2b01696356ed4652accf093f6c6a47ee
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-2-A.yml
+++ b/model/questions/D-SR-2-A.yml
@@ -6,7 +6,7 @@
 activity: 1cc77725cb2349f394477838668f6184
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-2-B.yml
+++ b/model/questions/D-SR-2-B.yml
@@ -6,7 +6,7 @@
 activity: 5d5e3d9beab9498ca1ce66d3a53a81c6
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-3-A.yml
+++ b/model/questions/D-SR-3-A.yml
@@ -6,7 +6,7 @@
 activity: ce13df2e0dfb455588bf75135f1a718e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-SR-3-B.yml
+++ b/model/questions/D-SR-3-B.yml
@@ -6,7 +6,7 @@
 activity: a9f56795ac84426c9e45f9471e82a8d7
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-1-A.yml
+++ b/model/questions/D-TA-1-A.yml
@@ -6,7 +6,7 @@
 activity: c6da6525773644d0a18b3a927caf6dd2
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-1-B.yml
+++ b/model/questions/D-TA-1-B.yml
@@ -7,7 +7,7 @@ activity: 1ceadbb5a0024e2599821e7ce756f3a4
 
 #Link to the answer set that contains the potential answers for this question
 
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-2-A.yml
+++ b/model/questions/D-TA-2-A.yml
@@ -6,7 +6,7 @@
 activity: 529d528265c94447954a57f5be425f54
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-2-B.yml
+++ b/model/questions/D-TA-2-B.yml
@@ -6,7 +6,7 @@
 activity: 649b693315234a94928e42f3e308deac
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-3-A.yml
+++ b/model/questions/D-TA-3-A.yml
@@ -6,7 +6,7 @@
 activity: 2f63f92c414546b58d035ece110d479f
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f3534ade73d8469e879c74b4e0a4eb3d
+answerSet: f3534ade73d8469e879c74b4e0a4eb3d
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/D-TA-3-B.yml
+++ b/model/questions/D-TA-3-B.yml
@@ -6,7 +6,7 @@
 activity: e931a744c2864bef85a3fa75ce7e214f
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 01b2ac64461d4ec6b40843a4c77e1ba6
+answerSet: 01b2ac64461d4ec6b40843a4c77e1ba6
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-1-A.yml
+++ b/model/questions/G-EG-1-A.yml
@@ -6,7 +6,7 @@
 activity: 93ccc4cdf5d841e3986f3684467b2bf1
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-1-B.yml
+++ b/model/questions/G-EG-1-B.yml
@@ -6,7 +6,7 @@
 activity: ebd3782abc4343509981c52192904a42
 
 #Link to the answer set that contains the potential answers for this question
-answerset: a0d515d66004425e8039cf4197fce271
+answerSet: a0d515d66004425e8039cf4197fce271
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-2-A.yml
+++ b/model/questions/G-EG-2-A.yml
@@ -6,7 +6,7 @@
 activity: 05073fb130c74143a12a6ba74a44c580
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f96770095fab4afbb27949c2242e47c2
+answerSet: f96770095fab4afbb27949c2242e47c2
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-2-B.yml
+++ b/model/questions/G-EG-2-B.yml
@@ -6,7 +6,7 @@
 activity: d61764610f8741de894c1751f5c041ae
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 3d4c5c80278b4a58b80d559085804446
+answerSet: 3d4c5c80278b4a58b80d559085804446
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-3-A.yml
+++ b/model/questions/G-EG-3-A.yml
@@ -6,7 +6,7 @@
 activity: a061ed8a5b1c4899bc95d9b1a10a469d
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f96770095fab4afbb27949c2242e47c2
+answerSet: f96770095fab4afbb27949c2242e47c2
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-EG-3-B.yml
+++ b/model/questions/G-EG-3-B.yml
@@ -6,7 +6,7 @@
 activity: a3720e84d6a24a8ba235c25ce6afc5c7
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 3d4c5c80278b4a58b80d559085804446
+answerSet: 3d4c5c80278b4a58b80d559085804446
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-1-A.yml
+++ b/model/questions/G-PC-1-A.yml
@@ -6,7 +6,7 @@
 activity: 6e7a618abd564df5bb784ca54893bbee
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-1-B.yml
+++ b/model/questions/G-PC-1-B.yml
@@ -6,7 +6,7 @@
 activity: 852c76292e8a41de92205b31cb3f4e49
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-2-A.yml
+++ b/model/questions/G-PC-2-A.yml
@@ -6,7 +6,7 @@
 activity: 09f4b814a3444b329a7c9c7f54152ffe
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 9a87d689fe35441aabf1ad4b7048b61e
+answerSet: 9a87d689fe35441aabf1ad4b7048b61e
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-2-B.yml
+++ b/model/questions/G-PC-2-B.yml
@@ -6,7 +6,7 @@
 activity: 38932fe4024e4ec89646a82e0b4e651e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f5042ff6c8d44068a9ac3e1bd8349760
+answerSet: f5042ff6c8d44068a9ac3e1bd8349760
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-3-A.yml
+++ b/model/questions/G-PC-3-A.yml
@@ -6,7 +6,7 @@
 activity: fe7afe5fc04742bcbe476d4ba37d8091
 
 #Link to the answer set that contains the potential answers for this question
-answerset: e0fcc49a200847eab218c04e2c80490a
+answerSet: e0fcc49a200847eab218c04e2c80490a
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-PC-3-B.yml
+++ b/model/questions/G-PC-3-B.yml
@@ -6,7 +6,7 @@
 activity: e7ba346fabdc44beb47e2c67c14a6726
 
 #Link to the answer set that contains the potential answers for this question
-answerset: e0fcc49a200847eab218c04e2c80490a
+answerSet: e0fcc49a200847eab218c04e2c80490a
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-1-A.yml
+++ b/model/questions/G-SM-1-A.yml
@@ -6,7 +6,7 @@
 activity: ef0b56870b734b13868697017a9b605e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f678b7a00f2441148087d48f8e0a6ad1
+answerSet: f678b7a00f2441148087d48f8e0a6ad1
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-1-B.yml
+++ b/model/questions/G-SM-1-B.yml
@@ -6,7 +6,7 @@
 activity: 0082a76b1a3744d9ab0443bd2168e13d
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 608f87d59da44e589f0090790675ed23
+answerSet: 608f87d59da44e589f0090790675ed23
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-2-A.yml
+++ b/model/questions/G-SM-2-A.yml
@@ -6,7 +6,7 @@
 activity: c1778728d66e4b83b59a42405a90598a
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 66e3e11eb8404fb6880377e539609678
+answerSet: 66e3e11eb8404fb6880377e539609678
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-2-B.yml
+++ b/model/questions/G-SM-2-B.yml
@@ -6,7 +6,7 @@
 activity: c1aef0137df1400cbdd3c660b609b7b2
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 439e7b91e6b446ae83b4d1efe831a97d
+answerSet: 439e7b91e6b446ae83b4d1efe831a97d
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-3-A.yml
+++ b/model/questions/G-SM-3-A.yml
@@ -6,7 +6,7 @@
 activity: e092ac0ccb8c4fccb6cd662f974dc107
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 01b2ac64461d4ec6b40843a4c77e1ba6
+answerSet: 01b2ac64461d4ec6b40843a4c77e1ba6
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/G-SM-3-B.yml
+++ b/model/questions/G-SM-3-B.yml
@@ -6,7 +6,7 @@
 activity: 43d347fd280845718f16ccc811e5d942
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 01b2ac64461d4ec6b40843a4c77e1ba6
+answerSet: 01b2ac64461d4ec6b40843a4c77e1ba6
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-1-A.yml
+++ b/model/questions/I-DM-1-A.yml
@@ -6,7 +6,7 @@
 activity: 93dff7be5f954f8d87d24f4261002508
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-1-B.yml
+++ b/model/questions/I-DM-1-B.yml
@@ -6,7 +6,7 @@
 activity: d1cb54f1ddd3432480513df320fc0ff8
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-2-A.yml
+++ b/model/questions/I-DM-2-A.yml
@@ -6,7 +6,7 @@
 activity: 2bf0e192a904444b8a2f38c33256e80a
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-2-B.yml
+++ b/model/questions/I-DM-2-B.yml
@@ -6,7 +6,7 @@
 activity: 15d73a64818c43019504c8d938ca2434
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-3-A.yml
+++ b/model/questions/I-DM-3-A.yml
@@ -6,7 +6,7 @@
 activity: d955a7b3fbfc4b6aa5b327af9e01c377
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-DM-3-B.yml
+++ b/model/questions/I-DM-3-B.yml
@@ -6,7 +6,7 @@
 activity: f2a309b82fbc46cfb2f11c9cde20dc0a
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-1-A.yml
+++ b/model/questions/I-SB-1-A.yml
@@ -6,7 +6,7 @@
 activity: bf536a9305134a769adbd414652054ee
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-1-B.yml
+++ b/model/questions/I-SB-1-B.yml
@@ -6,7 +6,7 @@
 activity: bed0489cae4e4401b1d44d56ad36c109
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-2-A.yml
+++ b/model/questions/I-SB-2-A.yml
@@ -6,7 +6,7 @@
 activity: bcc960e835aa4ad58a9d39a272cbf6f1
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-2-B.yml
+++ b/model/questions/I-SB-2-B.yml
@@ -6,7 +6,7 @@
 activity: 857a43e335ba467598eca99d48ea0076
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-3-A.yml
+++ b/model/questions/I-SB-3-A.yml
@@ -6,7 +6,7 @@
 activity: 281369f491da4d4c84b0729e344e2c93
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SB-3-B.yml
+++ b/model/questions/I-SB-3-B.yml
@@ -6,7 +6,7 @@
 activity: d09a731835304ea8aeb4c21565e45c4b
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-1-A.yml
+++ b/model/questions/I-SD-1-A.yml
@@ -6,7 +6,7 @@
 activity: 994bcac2bb7c4cc59a0faa365a0b58a0
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-1-B.yml
+++ b/model/questions/I-SD-1-B.yml
@@ -6,7 +6,7 @@
 activity: 77a5f467ffe140e2a2839bb522e82c4e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-2-A.yml
+++ b/model/questions/I-SD-2-A.yml
@@ -6,7 +6,7 @@
 activity: 1f3a9306778f4539a437d9f19232cda7
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-2-B.yml
+++ b/model/questions/I-SD-2-B.yml
@@ -6,7 +6,7 @@
 activity: 4729b4bd6dca4d58a68cb854ad4409a6
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-3-A.yml
+++ b/model/questions/I-SD-3-A.yml
@@ -6,7 +6,7 @@
 activity: 05a3e75c6c654ae58a115cbf4295662b
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/I-SD-3-B.yml
+++ b/model/questions/I-SD-3-B.yml
@@ -6,7 +6,7 @@
 activity: fed0d75c064c4a979a5b7b98adfdedbf
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-1-A.yml
+++ b/model/questions/O-EM-1-A.yml
@@ -6,7 +6,7 @@
 activity: 786b3d7b39cd49a88090554a275f04a6
 
 #This question uses Answer Set T
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-1-B.yml
+++ b/model/questions/O-EM-1-B.yml
@@ -6,7 +6,7 @@
 activity: 0721d5bd5d67479991b5b52f33dcd7b1
 
 #This question uses Answer Set G
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-2-A.yml
+++ b/model/questions/O-EM-2-A.yml
@@ -6,7 +6,7 @@
 activity: 84dcbc954d954d95b1fb37e032f05402
 
 #This question uses Answer Set G
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-2-B.yml
+++ b/model/questions/O-EM-2-B.yml
@@ -6,7 +6,7 @@
 activity: b7f1d18fbe724a148f039ce036de98ef
 
 #This question uses Answer Set G
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-3-A.yml
+++ b/model/questions/O-EM-3-A.yml
@@ -6,7 +6,7 @@
 activity: 3156ab7b516e4550893427face9f86bc
 
 #This question uses Answer Set G
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-EM-3-B.yml
+++ b/model/questions/O-EM-3-B.yml
@@ -6,7 +6,7 @@
 activity: a573c126b3e345fba9d1d94c8158cf60
 
 #This question uses Answer Set G
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-1-A.yml
+++ b/model/questions/O-IM-1-A.yml
@@ -6,7 +6,7 @@
 activity: b8dfd23d66224ac88d3ce41cf83ed15e
 
 #This question uses Answer Set A
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-1-B.yml
+++ b/model/questions/O-IM-1-B.yml
@@ -6,7 +6,7 @@
 activity: b082664b8815407d825b82cf23fa88ea
 
 #This question uses Answer Set H
-answerset: 381e1e37a19c488ab045a8a512552141
+answerSet: 381e1e37a19c488ab045a8a512552141
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-2-A.yml
+++ b/model/questions/O-IM-2-A.yml
@@ -6,7 +6,7 @@
 activity: 5bcb52375a0f4085bb12266c9ecfa84d
 
 #This question uses Answer Set A
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-2-B.yml
+++ b/model/questions/O-IM-2-B.yml
@@ -6,7 +6,7 @@
 activity: d6dd8813c5074350b5614b92f2dec60d
 
 #This question uses Answer Set I
-answerset: e5a12ab46e4645a9ab22aa5a1ebe562f
+answerSet: e5a12ab46e4645a9ab22aa5a1ebe562f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-3-A.yml
+++ b/model/questions/O-IM-3-A.yml
@@ -6,7 +6,7 @@
 activity: 11dd0c95f8914b6cb850a27f0557a9dd
 
 #This question uses Answer Set A
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-IM-3-B.yml
+++ b/model/questions/O-IM-3-B.yml
@@ -6,7 +6,7 @@
 activity: f692ee8f87c1499681490cc1647c0df4
 
 #This question uses Answer Set E
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-1-A.yml
+++ b/model/questions/O-OM-1-A.yml
@@ -6,7 +6,7 @@
 activity: c16a12399dc94cc889d7e9e66e0ae2a0
 
 #This question uses Answer Set A
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-1-B.yml
+++ b/model/questions/O-OM-1-B.yml
@@ -6,7 +6,7 @@
 activity: 1a398709b9d3407dbf9db7eeff6e916c
 
 #This question uses Answer Set A
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-2-A.yml
+++ b/model/questions/O-OM-2-A.yml
@@ -6,7 +6,7 @@
 activity: 82a962e3dcc44b1086760de517aaa3c1
 
 #This question uses Answer Set J
-answerset: 6c3e82e127264b92b25b732d85286d72
+answerSet: 6c3e82e127264b92b25b732d85286d72
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-2-B.yml
+++ b/model/questions/O-OM-2-B.yml
@@ -6,7 +6,7 @@
 activity: 60d7a0a61dd142d5a87009bc5b93df56
 
 #This question uses Answer Set E
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-3-A.yml
+++ b/model/questions/O-OM-3-A.yml
@@ -6,7 +6,7 @@
 activity: cd80066899014962a37af7ab34c83003
 
 #This question uses Answer Set K
-answerset: 14ad9a12e44f4079abc610010292f35e
+answerSet: 14ad9a12e44f4079abc610010292f35e
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/O-OM-3-B.yml
+++ b/model/questions/O-OM-3-B.yml
@@ -6,7 +6,7 @@
 activity: 8ab46d242edd413d99a6c1991aef2416
 
 #This question uses Answer Set L
-answerset: c1d15e1f5c8946d381f508db29b26473
+answerSet: c1d15e1f5c8946d381f508db29b26473
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-1-A.yml
+++ b/model/questions/V-AA-1-A.yml
@@ -6,7 +6,7 @@
 activity: 0f611af10f974da497e7f3defe0c4f12
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-1-B.yml
+++ b/model/questions/V-AA-1-B.yml
@@ -6,7 +6,7 @@
 activity: 3ae763a70854421984dfa70980e1bf68
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-2-A.yml
+++ b/model/questions/V-AA-2-A.yml
@@ -6,7 +6,7 @@
 activity: eba4b86963f44fa59b0b9389a1cfc59b
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-2-B.yml
+++ b/model/questions/V-AA-2-B.yml
@@ -6,7 +6,7 @@
 activity: 62237ae79ab84a6687de2885b1e3d608
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-3-A.yml
+++ b/model/questions/V-AA-3-A.yml
@@ -6,7 +6,7 @@
 activity: 9d0433c5133c4a4c9c16ae84abe9a235
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-AA-3-B.yml
+++ b/model/questions/V-AA-3-B.yml
@@ -6,7 +6,7 @@
 activity: a11da5bb4d3c475d9e9c53b104032e65
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-1-A.yml
+++ b/model/questions/V-RT-1-A.yml
@@ -6,7 +6,7 @@
 activity: 99989f86dabc4a7a87fbe6a274c99ca3
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-1-B.yml
+++ b/model/questions/V-RT-1-B.yml
@@ -6,7 +6,7 @@
 activity: 81ef5625583646bf8bc3fad53e4eff55
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-2-A.yml
+++ b/model/questions/V-RT-2-A.yml
@@ -6,7 +6,7 @@
 activity: 9951bda24b624cc684a2851f9d56c5d8
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-2-B.yml
+++ b/model/questions/V-RT-2-B.yml
@@ -6,7 +6,7 @@
 activity: fd4d1ac720374b13a25ab1381045b731
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-3-A.yml
+++ b/model/questions/V-RT-3-A.yml
@@ -6,7 +6,7 @@
 activity: 7003146cf1a1450293001754fe74787d
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-RT-3-B.yml
+++ b/model/questions/V-RT-3-B.yml
@@ -6,7 +6,7 @@
 activity: d975bb1ce1dd4d61a6039b0a4a05926e
 
 #Link to the answer set that contains the potential answers for this question
-answerset: d096060a4d864133afcbdd1397b95827
+answerSet: d096060a4d864133afcbdd1397b95827
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-1-A.yml
+++ b/model/questions/V-ST-1-A.yml
@@ -6,7 +6,7 @@
 activity: 921ff24f0b9f4df9a5129aa2f8a4a570
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-1-B.yml
+++ b/model/questions/V-ST-1-B.yml
@@ -6,7 +6,7 @@
 activity: b3b20a75740c4880a21ad9aa0c1298c7
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 612bf4ec249f4e9d86f9e36dbf511821
+answerSet: 612bf4ec249f4e9d86f9e36dbf511821
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-2-A.yml
+++ b/model/questions/V-ST-2-A.yml
@@ -6,7 +6,7 @@
 activity: fb6f258a2e424ee9a919341758222a7a
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 8c89e8daf71d425abaca53edc01f6afa
+answerSet: 8c89e8daf71d425abaca53edc01f6afa
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-2-B.yml
+++ b/model/questions/V-ST-2-B.yml
@@ -6,7 +6,7 @@
 activity: 346ed576f0a94147ba2b8148abc3c73a
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f77bd45a28c8493dbba6e53b2eafa20f
+answerSet: f77bd45a28c8493dbba6e53b2eafa20f
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-3-A.yml
+++ b/model/questions/V-ST-3-A.yml
@@ -6,7 +6,7 @@
 activity: 4f6a06796d0840debcc775ea1af65679
 
 #Link to the answer set that contains the potential answers for this question
-answerset: f0ccf7b66c0a484aa8374a387438bc98
+answerSet: f0ccf7b66c0a484aa8374a387438bc98
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.

--- a/model/questions/V-ST-3-B.yml
+++ b/model/questions/V-ST-3-B.yml
@@ -6,7 +6,7 @@
 activity: a395d69917b947b28d5995738d716283
 
 #Link to the answer set that contains the potential answers for this question
-answerset: 51466c3df15b45119e3fc68293f16034
+answerSet: 51466c3df15b45119e3fc68293f16034
 
 #Unique identifier (GUID) used to refer to this maturity level.
 #Please generate another identifier for your specific maturity level.


### PR DESCRIPTION
The properties in some of the models where using an inconsistent naming scheme.

Questions: answerset -> answerSet
PracticeLevels: maturitylevel -> maturityLevel

Important!!!
This change could potentially break applications which depends on the inconsistent naming and have used explicit translations during deserialization.