### PR TITLE
Markdown generate

### DIFF
--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           mkdir output
       - name: 'Generate model for website'
-        uses: docker://fzipi/owasp-samm-preprocess-yaml:version-0.8.1
+        uses: docker://backnot/owasp-samm-process-yaml-content:latest
         with:
           args: '-d model -o output'
       - name: 'Move generated files to common directory structure'

--- a/model/questions/D-SR-3-B.yml
+++ b/model/questions/D-SR-3-B.yml
@@ -21,8 +21,8 @@ order: 1
 
 #Qualifying Criterion
 quality:
-- The vendor has a secure SDLC that includes secure build, secure deployment, defect 
-  management, and incident management, meets the security expectations of your organization, 
+- The vendor has a secure SDLC that includes secure build, secure deployment, defect
+  management, and incident management, meets the security expectations of your organization,
   and is able to demonstrate operating effectiveness of practices.
 - You verify the solution meets quality and security objectives before every major
   release

--- a/model/questions/G-EG-1-A.yml
+++ b/model/questions/G-EG-1-A.yml
@@ -28,7 +28,7 @@ quality:
   Management, Open Design, and Psychological Acceptability
 - Training requires a sign-off or an acknowledgement from attendees
 - You have reviewed the training content within the last 12 months, and have completed any required updates
-- All new covered staff are required to complete training during their onboarding process 
+- All new covered staff are required to complete training during their onboarding process
 - Existing covered staff are required to complete training when content is added/revised, or
   complete refresher training at least every 24 months, whichever comes first
 


### PR DESCRIPTION
Fixes #155 

Two problems were fixed - 

1.There are trailing whitespaces in two yaml files which are causing the "lintModelv20" job to fail.

2.The markdown generation uses docker image which has an issue (see https://github.com/owaspsamm/process-yaml-content/issues/4). I have created new docker image with the fix and released it under my DockerHub profile. 
I tagged it as "latest" because there is no newer version than v0.8.1 (see https://github.com/owaspsamm/process-yaml-content/issues/7). When a version for the yaml processor is created I can tag the image with the appropriate number.

However I suggest that you create new DockerHub OWASP SAMM profile and we upload the image there (we can do it in Lisbon next week). After that we should change the workflow yaml file to use the new image.

After this pull request markdown generation will work as designed - when pushing a new "tag" or manually triggered by the "Actions" tab - "Generate web markdown". Markdown will be generated on a new branch that starts with "markdown/..."