### PR TITLE
Fixed "trigger-website-build" job condition. Changed job to use user token instead of default github token as a secret.

### DIFF
--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -66,14 +66,14 @@ jobs:
           SQUASH_HISTORY: true
   # after changing something, we need to trigger the website build
   trigger-website-build:
-    if: github.event.push.tags && github.ref_type == 'tag'
+    if: github.event_name == "push" && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs: generate-markdown
     steps:
       - name: Trigger Website Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OWASP_SAMM_WEBSITE_TOKEN }}
           repository: owaspsamm/website
           event-type: samm-core-released
           client-payload: '{"release": "${{ github.ref_name }}"}'


### PR DESCRIPTION
When the correct token with access to the SAMM website repository is created as secret to this project (with name OWASP_SAMM_WEBSITE_TOKEN) the repository dispatch event will work when new tag is created and the other repository will be notified that there is new version of the core model.
