### PR TITLE
Release workflow deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
             echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
   generate-markdown-build-website:
     needs: release
-    uses: owaspsamm/core/.github/workflows/yaml-process.yml@203087a6af7f300a42ebc56a399500510e8db490
+    uses: owaspsamm/core/.github/workflows/yaml-process.yml@7cdf8a9a0cc583bfe597a11ff5b2de44960a4575
     secrets: inherit
     with:
       release: ${{ needs.release.outputs.BRANCH_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - closed
 jobs:
   release:
+    outputs:
+      BRANCH_NAME: ${{ steps.releaseInfo.outputs.BRANCH_NAME }}
+      RELEASE_VERSION: ${{ steps.releaseInfo.outputs.RELEASE_VERSION }}
     name: Publish new release
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true     # only merged pull requests must trigger this job
@@ -38,6 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: ncipollo/release-action@v1
         with:
+          commit: main
           artifacts: samm.tar.gz, SAMM_spreadsheet.xlsx
           tag: ${{ env.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,3 +57,17 @@ jobs:
           body: |
             This PR merges the main branch back into develop.
             This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates are also present on the develop branch.
+      - name: Passing release information for next job
+        id: releaseInfo
+        env:
+          BRANCH_NAME: "${{ github.event.pull_request.head.ref }}"
+        run: |
+            echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+            echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+  generate-markdown-build-website:
+    needs: release
+    uses: owaspsamm/core/.github/workflows/yaml-process.yml@203087a6af7f300a42ebc56a399500510e8db490
+    secrets: inherit
+    with:
+      release: ${{ needs.release.outputs.BRANCH_NAME }}
+      release_name: ${{ needs.release.outputs.RELEASE_VERSION }}

--- a/.github/workflows/yaml-process.yml
+++ b/.github/workflows/yaml-process.yml
@@ -12,6 +12,18 @@ on:
         description: 'Generate Web Markdown for this SAMM release'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: string
+      release_name:
+        required: true
+        type: string
+      external_call:
+        default: true
+        required: false
+        type: boolean
 jobs:
   lintModelv20:
     runs-on: ubuntu-latest
@@ -24,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: lintModelv20
     steps:
-      - name: 'Checkout using release is workflow dispatched'
-        if: github.event_name == 'workflow_dispatch'
+      - name: 'Checkout using release is workflow dispatched or workflow call (reused from other workflow)'
+        if: github.event_name == 'workflow_dispatch' || inputs.external_call
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.release }}
@@ -42,6 +54,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo "release_name=${{ inputs.release }}" >> $GITHUB_ENV
+      - name: 'Checkout using release is workflow call (reused from other workflow)'
+        if: inputs.external_call
+        run: |
+          echo "release_name=${{ inputs.release_name }}" >> $GITHUB_ENV
       - name: 'Create output dir and copy files to override spaces in directories'
         run: |
           mkdir output
@@ -66,14 +82,26 @@ jobs:
           SQUASH_HISTORY: true
   # after changing something, we need to trigger the website build
   trigger-website-build:
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    if: (github.event_name == 'push' && github.ref_type == 'tag') || inputs.external_call || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: generate-markdown
     steps:
+      - name: 'Decide if version comes from push'
+        if: github.event_name == 'push'
+        run: |
+          echo "release_name=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: 'Decide if version comes from workflow dispatch'
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "release_name=${{ inputs.release }}" >> $GITHUB_ENV
+      - name: 'Decide if version comes from release (workflow call)'
+        if: inputs.external_call
+        run: |
+          echo "release_name=${{ inputs.release_name }}" >> $GITHUB_ENV
       - name: Trigger Website Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.OWASP_SAMM_WEBSITE_TOKEN }}
           repository: owaspsamm/website
           event-type: samm-core-released
-          client-payload: '{"release": "${{ github.ref_name }}"}'
+          client-payload: '{"release": "${{ env.release_name }}"}'


### PR DESCRIPTION
Updated release workflow to use the workflow to generate web markdown when new release is made. Allowed website deploy even when manual trigger of Generate markdown workflow is made. Changed the release tag to point to main branch commit instead of develop branch commit.